### PR TITLE
Respect supports_drop_table_cascade? in drop_table_with_cascade

### DIFF
--- a/lib/rails_sql_views/connection_adapters/abstract/schema_statements.rb
+++ b/lib/rails_sql_views/connection_adapters/abstract/schema_statements.rb
@@ -59,7 +59,8 @@ module RailsSqlViews
       end
 
       def drop_table_with_cascade(table_name, options = {})
-        execute "DROP TABLE #{quote_table_name(table_name)} CASCADE"
+        drop_behavior = supports_drop_table_cascade? ? 'CASCADE' : ''
+        execute "DROP TABLE #{quote_table_name(table_name)} #{drop_behavior}"
       end
       
       # Drop a view.


### PR DESCRIPTION
This allows drop_table to work correctly for SQLite databases.
