### PR TITLE
Deal with create view sql where tabs, newlines or space are used and retrieve view_definition from sys.objects

### DIFF
--- a/lib/rails_sql_views/connection_adapters/sqlserver_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/sqlserver_adapter.rb
@@ -21,8 +21,14 @@ module RailsSqlViews
       # Get the view select statement for the specified view.
       def view_select_statement(view, name=nil)
         q =<<-ENDSQL
-          SELECT view_definition FROM information_schema.views
-          WHERE table_name = '#{view}'
+          SELECT
+              SM.definition
+          FROM
+              sys.objects O
+              JOIN
+              sys.sql_modules SM ON o.object_id = SM.object_id
+          WHERE
+              o.type = 'V' AND o.name = '#{view}'
         ENDSQL
         
         view_def = select_value(q, name)

--- a/lib/rails_sql_views/connection_adapters/sqlserver_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/sqlserver_adapter.rb
@@ -36,7 +36,7 @@ module RailsSqlViews
       
       private
       def convert_statement(s)
-        s.sub(/^CREATE.* AS (select .*)/i, '\1').gsub(/\n/, '')
+        s.gsub(/\n/, ' ').sub(/.*CREATE VIEW.* AS.* (SELECT .*)/i, '\1')
       end
     end
   end


### PR DESCRIPTION
Because SQL Server stores raw sql statements for view creation we must ensure the Regexp responsible for extracting the select part of the view will be able to deal with newline/spaces and tabs properly.
With this PR the adapter will generate correct create_view statements for:

``` sql
        CREATE VIEW 'test' AS
        SELECT name,phone
        FROM person
```

Besides that it fix a limitation presented by the information_schema whose view_definition column has a limit of 4000 making it unapropriate for cases where view definition is larger than this limit.
